### PR TITLE
Use `gcloud app` instead of `gcloud preview app`

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -44,6 +44,6 @@ deployment:
         branch: master
         commands:
         # deploy to AppEngine
-        - gcloud -q preview app deploy app.yaml --promote --version=1
+        - gcloud -q app deploy app.yaml --promote --version=1
         # Run our E2E Test
         - python e2e_test.py


### PR DESCRIPTION
We should use `gcloud app` instead of `gcloud preview app` which will go away soon.
