### PR TITLE
Updating Prerequisites for Google Cloud Console and Circle copy changes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ See the [managed_vms](https://github.com/googlecloudplatform/continuous-deployme
 First, you must create a Cloud project. Two types of credentials are required. The first is a service account to authorize the gcloud command line tool in the Circle CI environment, which is used to deploy the project. The second is an API key used to access the Books API.
 
 * Create a Cloud project using the [Google Cloud Console](https://console.developer.google.com)
-* Under API Manager -> Google APIs, search and enable the Books API and the App Engine Admin APIs
-* Under Api Manager -> Credentials, click New Credentials -> API Key -> Server Key. Copy the key into api_key.py , see api_key.py.sample as a reference. Don't check api_key.py into the repository (it's already in the .gitignore).
-* Under Api Manager -> Credentials -> Service Account key, create a JSON key and download it.
+* Under APIs and Services -> API Library, search and enable the Books API and the App Engine Admin APIs
+* Under APIs and Services -> Credentials, click New Credentials -> API Key -> Server Key. Copy the key into api_key.py , see api_key.py.sample as a reference. Don't check api_key.py into the repository (it's already in the .gitignore).
+* Under APIs and Services -> Credentials, click New Credentials -> Service Account key, create a JSON key and download it.
 
 Both of the credentials need to be base64 encoded and added to the Circle CI project as an environment variable.
 
 * Go to [Circle CI](https://circleci.com). If you haven't already done so, create an account and enable your project.
-* On the top right, click `Project Settings`, then on the left click `Environment Variables`.
+* On the top right, click `Project Settings` -> `Environment Variables` -> `Add Variable`.
 * Base64 encode the client secret JSON file
 
     `base64 <your_secret.json>`
@@ -30,8 +30,8 @@ Both of the credentials need to be base64 encoded and added to the Circle CI pro
 
     `base64 api_key.py`
 *  Copy the output of the base64 command into the 'Value' form, with the Name field set to API_KEY. Click `Save Variable`.
-* In the circle.yaml file, replace the <your-project-id> in `gcloud config set project` with your project id.
-* In e2e_test.py, replace the <your-project-id> in the HOST variable with the URL your project will be deployed to `https://your-project-id.appspot.com`.
+* In the circle.yaml file, replace "continuous-deployment-circle" with your project id in `GCLOUD_PROJECT`.
+* In e2e_test.py, replace the URL in the HOST variable with the URL your project will be deployed to `https://your-project-id.appspot.com`.
 * Commit and push your changes. The circle project should run the local tests, then use the gcloud SDK (authenticated with the client-secret) to deploy to the appspot URL, then run the e2e tests against that URL.
 
 ## Contributing changes

--- a/circle.yml
+++ b/circle.yml
@@ -31,7 +31,7 @@ dependencies:
     - gcloud --quiet components update app
     # authenticate gcloud
     - gcloud auth activate-service-account --key-file ${HOME}/client-secret.json
-    # Replace <your-project-id>
+    # Set project id
     - gcloud config set project $GCLOUD_PROJECT
 
 test:


### PR DESCRIPTION
@waprin thanks for putting this together. Super helpful! 😄 

# Changes

A few updates found when stepping through Prerequisites:
- `API Manager` -> `APIs and Services`,
- `Google APIs` -> `API Library`,
- `<your-project-id>` in `gcloud config set project` has been extracted to `GCLOUD_PROJECT` variable, but not updated in Prerequisites or the circle.yml comment
 
# Screenshots
![screen shot 2018-01-11 at 2 55 32 pm](https://user-images.githubusercontent.com/1916803/34851578-8852a998-f6df-11e7-8140-083014a561d7.png)
^ new GCP screen

Hope this helps. Thanks again!